### PR TITLE
Improve about section layout and project ordering

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -409,9 +409,25 @@ nav {
 }
 
 .about-content {
-    display: grid;
-    grid-template-columns: 3fr 2fr;
-    gap: 4rem;
+    display: flex;
+    justify-content: center;
+    position: relative;
+}
+
+.about-card {
+    position: relative;
+    width: min(100%, 900px);
+    background-color: rgba(10, 25, 47, 0.85);
+    border-radius: 16px;
+    padding: 160px 3rem 3rem;
+    box-shadow: 0 30px 60px rgba(0, 0, 0, 0.25);
+    overflow: visible;
+}
+
+.about-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
 }
 
 .about-text p {
@@ -423,7 +439,8 @@ nav {
     display: flex;
     flex-direction: column;
     gap: 1rem;
-    margin: 2rem 0;
+    margin: 2rem 0 1rem;
+    align-items: flex-start;
 }
 
 .detail-item {
@@ -441,22 +458,34 @@ blockquote {
     padding-left: 1rem;
     font-style: italic;
     color: var(--color-text-primary);
-    margin: 2rem 0;
+    margin: 1rem 0 0;
+}
+
+.about-body blockquote {
+    align-self: flex-start;
+    max-width: 600px;
 }
 
 .about-image {
-    position: relative;
+    position: absolute;
+    top: -110px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 220px;
 }
 
 .image-container {
-    position: relative;
     width: 100%;
-    height: 300px;
-    border-radius: 4px;
-    background-color: var(--color-bg-secondary);
-    display: flex;
-    justify-content: center;
-    align-items: center;
+    height: 220px;
+    border-radius: 50%;
+    background: rgba(100, 255, 218, 0.12);
+    border: 4px solid var(--color-accent);
+    overflow: hidden;
+    box-shadow: 0 25px 45px rgba(100, 255, 218, 0.2);
+}
+
+.about-card .profile-image {
+    height: 100%;
 }
 
 .terminal-decoration {
@@ -1003,16 +1032,16 @@ footer {
     :root {
         --container-width-lg: var(--container-width-md);
     }
-    
-    .about-content {
-        grid-template-columns: 1fr;
-        gap: 2rem;
+
+    .about-card {
+        padding: 150px 2.5rem 2.5rem;
     }
-    
+
     .about-image {
-        order: -1;
+        width: 200px;
+        top: -100px;
     }
-    
+
     .dashboard-grid {
         grid-template-columns: 1fr;
     }
@@ -1022,7 +1051,16 @@ footer {
     :root {
         --container-width-md: var(--container-width-sm);
     }
-    
+
+    .about-card {
+        padding: 140px 1.5rem 2rem;
+    }
+
+    .about-image {
+        width: 180px;
+        top: -90px;
+    }
+
     .nav-links {
         position: fixed;
         top: var(--header-height);

--- a/index.html
+++ b/index.html
@@ -131,31 +131,34 @@
                 <h2><span class="accent">#</span> About Me</h2>
             </div>
             <div class="about-content">
-                <div class="about-text">
-                    <p>Computer Engineering student at the University of Córdoba, with a specialization in Computing and a strong focus on cybersecurity and software development, keeping up with the latest trends in computer security, development y usar herramientas con IA.</p>
-                    <p>Siempre tengo un proyecto en la cabeza, soy incapaz de permitirme aburrirme. I am currently finishing my studies, including internships and my Final Degree Project.</p>
-                    <p>I specialize in creating secure and efficient solutions, applying cybersecurity principles in every project I undertake.</p>
-                    <div class="about-details">
-                        <div class="detail-item">
-                            <i class="fas fa-map-marker-alt"></i>
-                            <span>Córdoba, Spain</span>
-                        </div>
-                        <div class="detail-item">
-                            <i class="fas fa-envelope"></i>
-                            <span>javiergc100@protonmail.com</span>
-                        </div>
-                        <div class="detail-item">
-                            <i class="fab fa-github"></i>
-                            <span>github.com/i12gocaj</span>
+                <div class="about-card">
+                    <div class="about-image">
+                        <div class="image-container">
+                            <img src="assets/img/profile.jpg" alt="Javier González Casares" class="profile-image">
                         </div>
                     </div>
-                    <blockquote>
-                        "As a kid, I used to break things by accident — now I do it on purpose."
-                    </blockquote>
-                </div>
-                <div class="about-image">
-                    <div class="image-container">
-                        <img src="assets/img/profile.jpg" alt="Javier González Casares" class="profile-image">
+                    <div class="about-body">
+                        <div class="about-text">
+                            <p>Computer Engineering student at the University of Córdoba, specializing in Computing with a strong focus on cybersecurity and software development while staying current with the latest security trends and AI-powered tooling.</p>
+                            <p>I always keep a project in mind and never allow boredom to settle in. I am currently finishing my studies, including internships and my Final Degree Project.</p>
+                        </div>
+                        <div class="about-details">
+                            <div class="detail-item">
+                                <i class="fas fa-map-marker-alt"></i>
+                                <span>Córdoba, Spain</span>
+                            </div>
+                            <div class="detail-item">
+                                <i class="fas fa-envelope"></i>
+                                <span>javiergc100@protonmail.com</span>
+                            </div>
+                            <div class="detail-item">
+                                <i class="fab fa-github"></i>
+                                <span>github.com/i12gocaj</span>
+                            </div>
+                        </div>
+                        <blockquote>
+                            "As a kid, I used to break things by accident — now I do it on purpose."
+                        </blockquote>
                     </div>
                 </div>
             </div>
@@ -365,7 +368,7 @@
                                 <i class="fas fa-bolt"></i>
                             </div>
                             <div class="skill-info">
-                                <h4>Pro active a tope</h4>
+                                <h4>Proactive</h4>
                                 <div class="skill-bar">
                                     <div class="skill-level" style="width: 95%"></div>
                                 </div>
@@ -526,6 +529,43 @@
                 <div class="project-card">
                     <div class="project-image">
                         <div class="project-placeholder">
+                            <i class="fas fa-network-wired"></i>
+                        </div>
+                    </div>
+                    <div class="project-content">
+                        <h3>Network Monitor</h3>
+                        <p>Desktop application that reports real-time upload and download usage alongside latency, interface saturation, and alerting thresholds so users can understand the bandwidth footprint of their devices at any moment.</p>
+                        <div class="project-tech">
+                            <span>Python</span>
+                            <span>Monitoring</span>
+                            <span>Desktop</span>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="project-card">
+                    <div class="project-image">
+                        <div class="project-placeholder">
+                            <i class="fas fa-globe"></i>
+                        </div>
+                    </div>
+                    <div class="project-content">
+                        <h3>Web Manager - gslasalle.es</h3>
+                        <p>Ongoing stewardship of the Scouts La Salle Córdoba website, keeping content fresh, ensuring availability, and reinforcing secure communication for the entire community.</p>
+                        <div class="project-tech">
+                            <span>Web</span>
+                            <span>Maintenance</span>
+                            <span>SEO</span>
+                        </div>
+                        <div class="project-links">
+                            <a href="https://gslasalle.es" target="_blank" class="btn small">Website</a>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="project-card">
+                    <div class="project-image">
+                        <div class="project-placeholder">
                             <i class="fas fa-ship"></i>
                         </div>
                     </div>
@@ -541,7 +581,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div class="project-card">
                     <div class="project-image">
                         <div class="project-placeholder">
@@ -561,22 +601,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="project-card">
-                    <div class="project-image">
-                        <div class="project-placeholder">
-                            <i class="fas fa-network-wired"></i>
-                        </div>
-                    </div>
-                    <div class="project-content">
-                        <h3>Network Monitor</h3>
-                        <p>Desktop application that reports real-time upload and download usage alongside latency, interface saturation, and alerting thresholds so users can understand the bandwidth footprint of their devices at any moment.</p>
-                        <div class="project-tech">
-                            <span>Python</span>
-                            <span>Monitoring</span>
-                            <span>Desktop</span>
-                        </div>
-                    </div>
-                </div>
+
                 <div class="project-card">
                     <div class="project-image">
                         <div class="project-placeholder">
@@ -703,16 +728,6 @@
                 
                 <div class="timeline-item">
                     <div class="timeline-dot"></div>
-                    <div class="timeline-date">2021</div>
-                    <div class="timeline-content">
-                        <h3>Cybersecurity Course - III National League</h3>
-                        <h4>Civil Guard</h4>
-                        <p>Participation in the National Cybersecurity League organized by the Civil Guard.</p>
-                    </div>
-                </div>
-                
-                <div class="timeline-item">
-                    <div class="timeline-dot"></div>
                     <div class="timeline-date">2021 - 2025</div>
                     <div class="timeline-content">
                         <h3>Participation in Free Software and Cybersecurity & Networks Classrooms</h3>
@@ -727,6 +742,15 @@
                         <h3>Degree in Computer Engineering - Specialization in Computing</h3>
                         <h4>Higher Polytechnic School of Córdoba</h4>
                         <p>Training in software engineering, operating systems, networks, and cybersecurity.</p>
+                    </div>
+                </div>
+                <div class="timeline-item">
+                    <div class="timeline-dot"></div>
+                    <div class="timeline-date">2021</div>
+                    <div class="timeline-content">
+                        <h3>Cybersecurity Course - III National League</h3>
+                        <h4>Civil Guard</h4>
+                        <p>Participation in the National Cybersecurity League organized by the Civil Guard.</p>
                     </div>
                 </div>
                 <div class="timeline-item">
@@ -775,15 +799,6 @@
                         <h3>1st Prize in the 3rd Edition of Hackademics Forum CTF</h3>
                         <h4>Cybersecurity and Networks Classroom, EPSC</h4>
                         <p>Achieved 1st prize in the Hackademics Forum CTF, demonstrating advanced skills in cybersecurity challenge resolution and problem-solving.</p>
-                    </div>
-                </div>
-
-                <div class="timeline-item">
-                    <div class="timeline-dot"></div>
-                    <div class="timeline-date">2025 - Present</div>
-                    <div class="timeline-content">
-                        <h3>Web Manager - Scouts La Salle Córdoba</h3>
-                        <p>Managing the digital presence of the group and maintaining <a href="https://gslasalle.es" target="_blank" rel="noopener">gslasalle.es</a>, ensuring up-to-date content, infrastructure reliability, and secure communication channels.</p>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- redesign the About section with a centered overlay photo, English-only bio, and updated layout
- rename the proactive soft skill label and reorganize projects so Network Monitor is seventh with the gslasalle.es web manager entry eighth
- move the cybersecurity course timeline entry beneath the degree and shift the web manager role from experience to projects

## Testing
- python3 -m http.server 8000 (manual preview)


------
https://chatgpt.com/codex/tasks/task_e_68c9df68ac3c832c93a318cafbb6bcb8