### PR TITLE
Integrate loading animation into hero terminal and refine about section layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -98,49 +98,6 @@ img {
     object-fit: cover;
 }
 
-/* Preloader */
-#preloader {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: var(--color-bg-primary);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 9999;
-}
-
-#preloader .terminal-window {
-    width: 500px;
-    max-width: 90%;
-}
-
-.progress-bar {
-    width: 100%;
-    height: 4px;
-    background-color: var(--color-bg-secondary);
-    margin-top: 10px;
-    position: relative;
-    overflow: hidden;
-}
-
-.progress-bar .progress {
-    position: absolute;
-    top: 0;
-    left: 0;
-    height: 100%;
-    width: 0;
-    background-color: var(--color-accent);
-    animation: progress 2s ease-in-out forwards;
-}
-
-@keyframes progress {
-    0% { width: 0; }
-    100% { width: 100%; }
-}
-
 /* Header y Navegación */
 header {
     position: fixed;
@@ -352,10 +309,16 @@ nav {
     padding: 20px;
     font-family: var(--font-primary);
     font-size: 0.9rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
 }
 
 .line {
-    margin-bottom: 10px;
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+    width: 100%;
 }
 
 .prompt {
@@ -365,10 +328,16 @@ nav {
 
 .command {
     color: var(--color-text-primary);
+    display: inline-block;
 }
 
 .output {
     color: var(--color-text-secondary);
+    display: block;
+    flex: 1;
+    line-height: 1.6;
+    opacity: 1;
+    transition: opacity 0.3s ease;
 }
 
 .blink {
@@ -378,6 +347,34 @@ nav {
 @keyframes blink {
     0%, 100% { opacity: 1; }
     50% { opacity: 0; }
+}
+
+.terminal-progress-wrapper {
+    display: block;
+    width: 100%;
+    height: 4px;
+    background-color: rgba(100, 255, 218, 0.15);
+    border-radius: 999px;
+    overflow: hidden;
+    margin-top: 6px;
+}
+
+.terminal-progress {
+    display: block;
+    height: 100%;
+    width: 0;
+    background-color: var(--color-accent);
+    border-radius: inherit;
+    transform-origin: left;
+}
+
+.terminal-progress.animate {
+    animation: terminalProgress 1.4s ease forwards;
+}
+
+@keyframes terminalProgress {
+    0% { width: 0; }
+    100% { width: 100%; }
 }
 
 /* About Section */
@@ -408,10 +405,12 @@ nav {
     margin-top: 0.5rem;
 }
 
+
 .about-content {
     display: flex;
     justify-content: center;
     position: relative;
+    padding-top: 1.5rem;
 }
 
 .about-card {
@@ -419,15 +418,21 @@ nav {
     width: min(100%, 900px);
     background-color: rgba(10, 25, 47, 0.85);
     border-radius: 16px;
-    padding: 160px 3rem 3rem;
+    padding: 3.5rem 3rem;
     box-shadow: 0 30px 60px rgba(0, 0, 0, 0.25);
-    overflow: visible;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2.5rem;
 }
 
 .about-body {
     display: flex;
     flex-direction: column;
     gap: 1.5rem;
+    width: 100%;
+    max-width: 640px;
 }
 
 .about-text p {
@@ -463,20 +468,18 @@ blockquote {
 
 .about-body blockquote {
     align-self: flex-start;
-    max-width: 600px;
+    max-width: 100%;
 }
 
 .about-image {
-    position: absolute;
-    top: -110px;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 220px;
+    position: relative;
+    width: 240px;
+    margin: 0 auto;
 }
 
 .image-container {
     width: 100%;
-    height: 220px;
+    aspect-ratio: 1;
     border-radius: 50%;
     background: rgba(100, 255, 218, 0.12);
     border: 4px solid var(--color-accent);
@@ -485,7 +488,10 @@ blockquote {
 }
 
 .about-card .profile-image {
+    width: 100%;
     height: 100%;
+    object-fit: cover;
+    object-position: center 20%;
 }
 
 .terminal-decoration {
@@ -1034,12 +1040,11 @@ footer {
     }
 
     .about-card {
-        padding: 150px 2.5rem 2.5rem;
+        padding: 3rem 2.5rem;
     }
 
     .about-image {
-        width: 200px;
-        top: -100px;
+        width: 220px;
     }
 
     .dashboard-grid {
@@ -1053,12 +1058,29 @@ footer {
     }
 
     .about-card {
-        padding: 140px 1.5rem 2rem;
+        padding: 2.5rem 1.5rem;
+        gap: 2rem;
     }
 
     .about-image {
-        width: 180px;
-        top: -90px;
+        width: 200px;
+    }
+
+    .about-body {
+        align-items: center;
+        text-align: center;
+    }
+
+    .about-text p {
+        text-align: center;
+    }
+
+    .about-details {
+        align-items: center;
+    }
+
+    .about-body blockquote {
+        text-align: center;
     }
 
     .nav-links {

--- a/index.html
+++ b/index.html
@@ -19,32 +19,6 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
-    <!-- Preloader -->
-    <div id="preloader">
-        <div class="terminal-window">
-            <div class="terminal-header">
-                <div class="terminal-buttons">
-                    <span></span>
-                    <span></span>
-                    <span></span>
-                </div>
-                <div class="terminal-title">initializing...</div>
-            </div>
-            <div class="terminal-body">
-                <div class="line">
-                    <span class="prompt">$</span>
-                    <span class="command">loading_portfolio</span>
-                </div>
-                <div class="line">
-                    <span class="output">Loading resources...</span>
-                </div>
-                <div class="progress-bar">
-                    <div class="progress"></div>
-                </div>
-            </div>
-        </div>
-    </div>
-
     <!-- Header/Navigation -->
     <header>
         <nav>
@@ -83,6 +57,18 @@
                     <div class="terminal-title">terminal</div>
                 </div>
                 <div class="terminal-body">
+                    <div class="line">
+                        <span class="prompt">$</span>
+                        <span class="command loading-command" data-delay-after="1600" data-output-delay="120">loading_portfolio</span>
+                    </div>
+                    <div class="line">
+                        <span class="output">
+                            Loading resources...
+                            <span class="terminal-progress-wrapper">
+                                <span class="terminal-progress"></span>
+                            </span>
+                        </span>
+                    </div>
                     <div class="line">
                         <span class="prompt">$</span>
                         <span class="command">whoami</span>


### PR DESCRIPTION
## Summary
- embed the loading sequence directly inside the hero terminal with a progress bar and faster command playback
- remove the standalone preloader and update the typing script to support configurable delays
- rework the About card styling so the portrait stays centered, unobstructed and responsive across breakpoints

## Testing
- No automated tests (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c9e31aca64832c988ea040d9dcdf46