### PR TITLE
Remove duplicate contact info and adjust about photo framing

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -491,7 +491,7 @@ blockquote {
     width: 100%;
     height: 100%;
     object-fit: cover;
-    object-position: center 20%;
+    object-position: center 10%;
 }
 
 .terminal-decoration {

--- a/index.html
+++ b/index.html
@@ -128,20 +128,6 @@
                             <p>Computer Engineering student at the University of Córdoba, specializing in Computing with a strong focus on cybersecurity and software development while staying current with the latest security trends and AI-powered tooling.</p>
                             <p>I always keep a project in mind and never allow boredom to settle in. I am currently finishing my studies, including internships and my Final Degree Project.</p>
                         </div>
-                        <div class="about-details">
-                            <div class="detail-item">
-                                <i class="fas fa-map-marker-alt"></i>
-                                <span>Córdoba, Spain</span>
-                            </div>
-                            <div class="detail-item">
-                                <i class="fas fa-envelope"></i>
-                                <span>javiergc100@protonmail.com</span>
-                            </div>
-                            <div class="detail-item">
-                                <i class="fab fa-github"></i>
-                                <span>github.com/i12gocaj</span>
-                            </div>
-                        </div>
                         <blockquote>
                             "As a kid, I used to break things by accident — now I do it on purpose."
                         </blockquote>


### PR DESCRIPTION
## Summary
- remove the contact detail list beneath the About Me description to avoid duplication with the dedicated contact section
- tweak the About Me profile image positioning so the head remains fully visible inside the frame

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c9ec411b58832cb3ca2f52ec9f216f