### PR TITLE
Tighten documents spacing and polish project pagination

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -515,6 +515,8 @@ blockquote {
 /* Professional Documents */
 .documents {
     background-color: rgba(17, 34, 64, 0.3);
+    min-height: auto;
+    padding: 100px 0 60px;
 }
 
 .documents .section-header {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -400,6 +400,80 @@ document.addEventListener('DOMContentLoaded', function() {
     // Ejecutar inmediatamente y también después de un retraso para asegurar que los elementos estén cargados
     setupNavigationButtons();
     setTimeout(setupNavigationButtons, 1000);
+
+    // Pagination for Projects Section
+    const projectsGrid = document.querySelector('#projects .projects-grid');
+    if (projectsGrid) {
+        const projectCards = Array.from(projectsGrid.querySelectorAll('.project-card'));
+        const projectsPerPage = 6;
+        let currentPage = 1;
+
+        const updatePaginationControls = () => {
+            const totalPages = Math.ceil(projectCards.length / projectsPerPage);
+            const prevButton = document.getElementById('prev-page');
+            const nextButton = document.getElementById('next-page');
+            const pageInfo = document.getElementById('page-info');
+
+            if (prevButton) prevButton.disabled = currentPage === 1;
+            if (nextButton) nextButton.disabled = currentPage === totalPages;
+            if (pageInfo) pageInfo.textContent = `Page ${currentPage} of ${totalPages}`;
+        };
+
+        const displayProjects = (page) => {
+            currentPage = page;
+            const startIndex = (page - 1) * projectsPerPage;
+            const endIndex = startIndex + projectsPerPage;
+
+            projectCards.forEach((card, index) => {
+                if (index >= startIndex && index < endIndex) {
+                    card.style.display = '';
+                } else {
+                    card.style.display = 'none';
+                }
+            });
+
+            updatePaginationControls();
+        };
+
+        const createPaginationControls = () => {
+            const paginationContainer = document.createElement('div');
+            paginationContainer.classList.add('pagination-controls');
+            projectsGrid.parentNode.insertBefore(paginationContainer, projectsGrid.nextSibling);
+
+            const prevButton = document.createElement('button');
+            prevButton.textContent = 'Previous';
+            prevButton.classList.add('btn', 'small');
+            prevButton.id = 'prev-page';
+            prevButton.addEventListener('click', () => {
+                if (currentPage > 1) {
+                    displayProjects(currentPage - 1);
+                }
+            });
+            paginationContainer.appendChild(prevButton);
+
+            const pageInfo = document.createElement('span');
+            pageInfo.id = 'page-info';
+            pageInfo.classList.add('page-info');
+            paginationContainer.appendChild(pageInfo);
+
+            const nextButton = document.createElement('button');
+            nextButton.textContent = 'Next';
+            nextButton.classList.add('btn', 'small');
+            nextButton.id = 'next-page';
+            nextButton.addEventListener('click', () => {
+                const totalPages = Math.ceil(projectCards.length / projectsPerPage);
+                if (currentPage < totalPages) {
+                    displayProjects(currentPage + 1);
+                }
+            });
+            paginationContainer.appendChild(nextButton);
+
+            updatePaginationControls();
+        };
+
+        createPaginationControls();
+        displayProjects(1);
+    }
 });
 
 // Estilos adicionales para animaciones
@@ -422,78 +496,4 @@ document.head.insertAdjacentHTML('beforeend', `
 </style>
 `);
 
-
-// Pagination for Projects Section
-const projectsGrid = document.querySelector('#projects .projects-grid');
-const projectCards = Array.from(projectsGrid.querySelectorAll('.project-card'));
-const projectsPerPage = 6;
-let currentPage = 1;
-
-function displayProjects(page) {
-    currentPage = page;
-    const startIndex = (page - 1) * projectsPerPage;
-    const endIndex = startIndex + projectsPerPage;
-
-    projectCards.forEach((card, index) => {
-        if (index >= startIndex && index < endIndex) {
-            card.style.display = 'block';
-        } else {
-            card.style.display = 'none';
-        }
-    });
-
-    updatePaginationControls();
-}
-
-function createPaginationControls() {
-    const paginationContainer = document.createElement('div');
-    paginationContainer.classList.add('pagination-controls');
-    projectsGrid.parentNode.insertBefore(paginationContainer, projectsGrid.nextSibling);
-
-    const prevButton = document.createElement('button');
-    prevButton.textContent = 'Previous';
-    prevButton.classList.add('btn', 'small');
-    prevButton.id = 'prev-page';
-    prevButton.addEventListener('click', () => {
-        if (currentPage > 1) {
-            displayProjects(currentPage - 1);
-        }
-    });
-    paginationContainer.appendChild(prevButton);
-
-    const pageInfo = document.createElement('span');
-    pageInfo.id = 'page-info';
-    pageInfo.classList.add('page-info');
-    paginationContainer.appendChild(pageInfo);
-
-    const nextButton = document.createElement('button');
-    nextButton.textContent = 'Next';
-    nextButton.classList.add('btn', 'small');
-    nextButton.id = 'next-page';
-    nextButton.addEventListener('click', () => {
-        if (currentPage < Math.ceil(projectCards.length / projectsPerPage)) {
-            displayProjects(currentPage + 1);
-        }
-    });
-    paginationContainer.appendChild(nextButton);
-
-    updatePaginationControls(); 
-}
-
-function updatePaginationControls() {
-    const totalPages = Math.ceil(projectCards.length / projectsPerPage);
-    const prevButton = document.getElementById('prev-page');
-    const nextButton = document.getElementById('next-page');
-    const pageInfo = document.getElementById('page-info');
-
-    if (prevButton) prevButton.disabled = currentPage === 1;
-    if (nextButton) nextButton.disabled = currentPage === totalPages;
-    if (pageInfo) pageInfo.textContent = `Page ${currentPage} of ${totalPages}`;
-}
-
-// Initialize pagination if project cards exist
-if (projectCards.length > 0) {
-    createPaginationControls();
-    displayProjects(1);
-}
 

--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@
             <div class="documents-actions">
                 <a href="assets/docs/cv-javier-gonzalez-casares.pdf" class="btn primary" download>Download CV</a>
                 <a href="assets/docs/carta-recomendacion-navantia.pdf" class="btn secondary" download>Recommendation Letter &mdash; Navantia</a>
-                <a href="assets/docs/carta-recomendacion-universidad.pdf" class="btn secondary" download>Recommendation Letter &mdash; Universidad</a>
+                <a href="assets/docs/carta-recomendacion-universidad.pdf" class="btn secondary" download>Recommendation Letter &mdash; University</a>
             </div>
         </div>
     </section>
@@ -556,7 +556,7 @@
 
                 <div class="timeline-item">
                     <div class="timeline-dot"></div>
-                    <div class="timeline-date">Current</div>
+                    <div class="timeline-date">Jun 2025 - Sep 2025</div>
                     <div class="timeline-content">
                         <h3>Cybersecurity Intern</h3>
                         <h4>Centro de Excelencia, Navantia Sistemas</h4>


### PR DESCRIPTION
## Summary
- rename the university recommendation letter button text for clarity
- trim the extra bottom space in the Professional Documents section
- initialize project pagination after DOM load so only six cards show per page and update the Navantia internship dates

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dda5c5d5a8832ca8dc699a42a9c122