### PR TITLE
Add Week 4 award entry and adjust project pagination

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -406,7 +406,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // Pagination for Projects Section
 
     class ProjectsPaginator {
-        constructor(gridElement, itemsPerPage = 6) {
+        constructor(gridElement, itemsPerPage = 4) {
             this.grid = gridElement;
             this.cards = Array.from(this.grid.querySelectorAll('.project-card'));
             this.itemsPerPage = Math.max(1, itemsPerPage);
@@ -534,7 +534,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const projectsGrid = document.querySelector('#projects .projects-grid');
     if (projectsGrid) {
-        new ProjectsPaginator(projectsGrid, 6);
+        new ProjectsPaginator(projectsGrid, 4);
     }
 });
 

--- a/index.html
+++ b/index.html
@@ -563,6 +563,16 @@
                         <p>Currently working as a cybersecurity intern at the Navantia Sistemas Center of Excellence.</p>
                     </div>
                 </div>
+
+                <div class="timeline-item">
+                    <div class="timeline-dot"></div>
+                    <div class="timeline-date">Sep 2025</div>
+                    <div class="timeline-content">
+                        <h3>Week 4 Winner — “El Bug de la Semana”</h3>
+                        <h4>INCIBE & IMMUNE</h4>
+                        <p>Recognized as the Week 4 winner in the “El Bug de la Semana” challenge organized by INCIBE and IMMUNE.</p>
+                    </div>
+                </div>
             </div>
         </div>
     </section>


### PR DESCRIPTION
## Summary
- add the Week 4 winner recognition for “El Bug de la Semana” to the experience timeline
- show four project cards per page by updating the projects paginator configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e523676f00832cbc3e7aa99300cd7d